### PR TITLE
use default random binary key for FernetEncrypter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     install_requires=[
-        "cryptojwt==1.8.0",
+        "cryptojwt>=1.8.1",
         "pyOpenSSL",
         "filelock>=3.0.12",
         'pyyaml>=5.1.2',

--- a/src/idpyoidc/encrypter.py
+++ b/src/idpyoidc/encrypter.py
@@ -11,8 +11,9 @@ def default_crypt_config():
     return {
         "class": DEFAULT_CRYPTO,
         "kwargs": {
-            "password": os.urandom(16),
-            "salt": os.urandom(16)
+            "key": os.urandom(32),
+            # "password": os.urandom(16),
+            # "salt": os.urandom(16)
             # "keys": {
             #     "key_defs": [
             #         {"type": "OCT", "use": ["enc"], "kid": "password"},

--- a/tests/private/token_jwks.json
+++ b/tests/private/token_jwks.json
@@ -1,1 +1,1 @@
-{"keys": [{"kty": "oct", "use": "enc", "kid": "code", "k": "dzuF9LxAjaXpfLhzHIpPAShUhTRph81z"}]}
+{"keys": [{"kty": "oct", "use": "enc", "kid": "code", "k": "vSHDkLBHhDStkR0NWu8519rmV5zmnm5_"}]}

--- a/tests/test_20_config.py
+++ b/tests/test_20_config.py
@@ -75,7 +75,7 @@ def test_entity_config(filename):
 def test_init_crypto_None():
     _res = init_crypto()
     assert _res["conf"]["class"] == DEFAULT_CRYPTO
-    assert set(_res["conf"]["kwargs"].keys()) == {"password", "salt"}
+    assert set(_res["conf"]["kwargs"].keys()) == {"key"}
     assert isinstance(_res["encrypter"], FernetEncrypter)
 
 


### PR DESCRIPTION
Use random binary key instead of key derived from password (that is already a random key)