### PR TITLE
Better handling on error in authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [metadata]
 name = "idpyoidc"
-version = "1.0.11"
+version = "1.0.12"
 author = "Roland Hedberg"
 author_email = "roland@catalogix.se"
 description = "Everything OAuth2 and OIDC"

--- a/src/idpyoidc/__init__.py
+++ b/src/idpyoidc/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Roland Hedberg"
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 
 import os
 from typing import Dict

--- a/src/idpyoidc/server/__init__.py
+++ b/src/idpyoidc/server/__init__.py
@@ -7,7 +7,6 @@ from typing import Union
 from cryptojwt import KeyJar
 
 from idpyoidc.impexp import ImpExp
-from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.server import authz
 from idpyoidc.server.client_authn import client_auth_setup
 from idpyoidc.server.configure import ASConfiguration

--- a/src/idpyoidc/server/cookie_handler.py
+++ b/src/idpyoidc/server/cookie_handler.py
@@ -39,13 +39,15 @@ class CookieHandler:
         name: Optional[dict] = None,
         **kwargs,
     ):
+        self.sign_key = None
+        self.enc_key = None
 
         if keys:
             key_jar = init_key_jar(**keys)
-            _keys = key_jar.get_signing_key(key_type="oct", kid="sig")
+            _keys = key_jar.get_signing_key(key_type="oct")
             if _keys:
                 self.sign_key = _keys[0]
-            _keys = key_jar.get_encrypt_key(key_type="oct", kid="enc")
+            _keys = key_jar.get_encrypt_key(key_type="oct")
             if _keys:
                 self.enc_key = _keys[0]
         else:

--- a/src/idpyoidc/server/cookie_handler.py
+++ b/src/idpyoidc/server/cookie_handler.py
@@ -279,15 +279,15 @@ class CookieHandler:
         LOGGER.debug("Looking for '{}' cookies".format(name))
         res = []
         for _cookie in cookies:
-            LOGGER.debug("Cookie: {}".format(_cookie))
+            LOGGER.debug(f"Cookie: {_cookie}")
             if "name" in _cookie and _cookie["name"] == name:
                 _content = self._ver_dec_content(_cookie["value"].split("|"))
                 if _content:
-                    payload, timestamp = self._ver_dec_content(_cookie["value"].split("|"))
+                    payload, timestamp = _content
                     value, typ = payload.split("::")
                     res.append({"value": value, "type": typ, "timestamp": timestamp})
                 else:
-                    LOGGER.debug(f"Could not verify {name} cookie")
+                    LOGGER.debug(f"Could not verify '{name}' cookie")
         return res
 
 

--- a/tests/private/cookie_jwks.json
+++ b/tests/private/cookie_jwks.json
@@ -1,1 +1,1 @@
-{"keys": [{"kty": "oct", "use": "enc", "kid": "enc", "k": "XlZGhRrHFOQwgIJZSV8g23cxVoL27xyv"}, {"kty": "oct", "use": "sig", "kid": "sig", "k": "TD6UZ7GmkUeC1oejdCGTf2YAp7FHeGfd"}]}
+{"keys": [{"kty": "oct", "use": "enc", "kid": "enc", "k": "G6JN24md0JKKBD16Aq02wPpvW6QrlgzI"}, {"kty": "oct", "use": "sig", "kid": "sig", "k": "8YmUB_TM3eW3-uZHUqgsuiXSkMpgboUk"}]}

--- a/tests/test_server_13_user_authn.py
+++ b/tests/test_server_13_user_authn.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from idpyoidc.server import Server
+from idpyoidc.server.authn_event import create_authn_event
 from idpyoidc.server.configure import OPConfiguration
 from idpyoidc.server.user_authn.authn_context import INTERNETPROTOCOLPASSWORD
 from idpyoidc.server.user_authn.authn_context import UNSPECIFIED
@@ -80,6 +81,20 @@ class TestUserAuthn(object):
         }
         self.server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
         self.endpoint_context = self.server.endpoint_context
+        self.session_manager = self.endpoint_context.session_manager
+        self.user_id = "diana"
+
+    def _create_session(self, auth_req, sub_type="public", sector_identifier=""):
+        if sector_identifier:
+            authz_req = auth_req.copy()
+            authz_req["sector_identifier_uri"] = sector_identifier
+        else:
+            authz_req = auth_req
+        client_id = authz_req["client_id"]
+        ae = create_authn_event(self.user_id)
+        return self.session_manager.create_session(
+            ae, authz_req, self.user_id, client_id=client_id, sub_type=sub_type
+        )
 
     def test_authenticated_as_without_cookie(self):
         authn_item = self.endpoint_context.authn_broker.pick(INTERNETPROTOCOLPASSWORD)
@@ -93,12 +108,11 @@ class TestUserAuthn(object):
         method = authn_item[0]["method"]
 
         authn_req = {"state": "state_identifier", "client_id": "client 12345"}
+        _sid = self._create_session(authn_req)
         _cookie = self.endpoint_context.new_cookie(
             name=self.endpoint_context.cookie_handler.name["session"],
             sub="diana",
-            sid=self.endpoint_context.session_manager.encrypted_session_id(
-                "diana", "client 12345", "abcdefgh"
-            ),
+            sid=_sid,
             state=authn_req["state"],
             client_id=authn_req["client_id"],
         )

--- a/tests/test_server_20g_cookie_handler.py
+++ b/tests/test_server_20g_cookie_handler.py
@@ -3,6 +3,7 @@ from cryptojwt.jwk.hmac import SYMKey
 
 from idpyoidc.server.cookie_handler import CookieHandler
 from idpyoidc.server.cookie_handler import compute_session_state
+from tests import CRYPT_CONFIG
 
 KEYDEFS = [
     {"type": "OCT", "kid": "sig", "use": ["sig"]},
@@ -233,3 +234,56 @@ class TestCookieHandlerSignEncKeys(object):
 def test_compute_session_state():
     hv = compute_session_state("state", "salt", "client_id", "https://example.com/redirect")
     assert hv == "d21113fbe4b54661ae45f3a3233b0f865ccc646af248274b6fa5664267540e29.salt"
+
+
+class TestCookieHandlerFernetEnc(object):
+    @pytest.fixture(autouse=True)
+    def make_cookie_content_handler(self):
+        cookie_conf = {
+            "crypt_config": CRYPT_CONFIG,
+        }
+
+        self.cookie_handler = CookieHandler(**cookie_conf)
+
+    def test_make_cookie_content(self):
+        _cookie_info = self.cookie_handler.make_cookie_content("idpyoidc.server", "value", "sso")
+        assert _cookie_info
+        assert set(_cookie_info.keys()) == {"name", "value", "samesite", "httponly", "secure"}
+        assert len(_cookie_info["value"].split("|")) == 2
+
+    def test_make_cookie_content_max_age(self):
+        _cookie_info = self.cookie_handler.make_cookie_content(
+            "idpyoidc.server", "value", "sso", max_age=3600
+        )
+        assert _cookie_info
+        assert set(_cookie_info.keys()) == {
+            "name",
+            "value",
+            "max-age",
+            "samesite",
+            "httponly",
+            "secure",
+        }
+        assert len(_cookie_info["value"].split("|")) == 2
+
+    def test_read_cookie_info(self):
+        _cookie_info = [self.cookie_handler.make_cookie_content("idpyoidc.server", "value", "sso")]
+        returned = [{"name": c["name"], "value": c["value"]} for c in _cookie_info]
+        _info = self.cookie_handler.parse_cookie("idpyoidc.server", returned)
+        assert len(_info) == 1
+        assert set(_info[0].keys()) == {"value", "type", "timestamp"}
+        assert _info[0]["value"] == "value"
+        assert _info[0]["type"] == "sso"
+
+    def test_mult_cookie(self):
+        _cookie = [
+            self.cookie_handler.make_cookie_content("idpyoidc.server", "value", "sso"),
+            self.cookie_handler.make_cookie_content("idpyoidc.server", "session_state", "session"),
+        ]
+        assert len(_cookie) == 2
+        _c_info = self.cookie_handler.parse_cookie("idpyoidc.server", _cookie)
+        assert len(_c_info) == 2
+        assert _c_info[0]["value"] == "value"
+        assert _c_info[0]["type"] == "sso"
+        assert _c_info[1]["value"] == "session_state"
+        assert _c_info[1]["type"] == "session"


### PR DESCRIPTION
If parsing cookies fail or if a session ID referenced in a cookie is not available then send the user to the log in page.