### PR TITLE
Handle missing token exchange requested_token_type parameter

### DIFF
--- a/src/idpyoidc/server/oauth2/token.py
+++ b/src/idpyoidc/server/oauth2/token.py
@@ -129,7 +129,13 @@ class Token(Endpoint):
         _context = self.server_get("endpoint_context")
 
         if isinstance(request, TokenExchangeRequest):
-            _handler_key = TOKEN_TYPES_MAPPING[request["requested_token_type"]]
+            requested_token_type = request.get(
+                "requested_token_type",
+                self.helper["urn:ietf:params:oauth:grant-type:token-exchange"].config[
+                    "default_requested_token_type"
+                ],
+            )
+            _handler_key = TOKEN_TYPES_MAPPING[requested_token_type]
         else:
             _handler_key = "access_token"
 

--- a/src/idpyoidc/server/oauth2/token_helper.py
+++ b/src/idpyoidc/server/oauth2/token_helper.py
@@ -392,6 +392,7 @@ class TokenExchangeHelper(TokenEndpointHelper):
                     "urn:ietf:params:oauth:token-type:access_token",
                     "urn:ietf:params:oauth:token-type:refresh_token",
                 ],
+                "default_requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
                 "policy": {"": {"callable": validate_token_exchange_policy}},
             }
         else:


### PR DESCRIPTION
According to [OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) the `requested_token_type` of a Token Exchange request is optional. In the case where this parameter is missing from the request, a KeyError is raised.

To solve this issue, this MR introduces a mandatory configuration parameter `default_requested_token_type` for the `TokenExchangeHelper` configuration.