### PR TITLE
Token exchange related fixes

### DIFF
--- a/doc/server/contents/conf.rst
+++ b/doc/server/contents/conf.rst
@@ -721,7 +721,7 @@ There are two possible ways to configure Token Exchange in OIDC-OP, globally and
 For the first case the configuration is passed in the Token Exchange handler throught the
 `urn:ietf:params:oauth:grant-type:token-exchange` dictionary in token's `grant_types_supported`.
 
-If present, the token exchange configuration may contain a `policy` dictionary
+If present, the token exchange configuration should contain a `policy` dictionary
 that defines the behaviour for each subject token type. Each subject token type
 is mapped to a dictionary with the keys `callable` (mandatory), which must be a
 python callable or a string that represents the path to a python callable, and
@@ -730,7 +730,14 @@ passed to the callable.
 
 The key `""` represents a fallback policy that will be used if the subject token
 type can't be found. If a subject token type is defined in the `policy` but is
-not in the `subject_token_types_supported` list then it is ignored::
+not in the `subject_token_types_supported` list then it is ignored.
+
+The token exchange configuration should also contain a `requested_token_types_supported`
+list that defines the supported token types that can be requested through the
+`requested_token_type` parameter of a Token Exchange request. In addition, a
+default token type that will be returned in the absence of the `requested_token_type`
+in the Token Exchange request should be defined through the `default_requested_token_type`
+configuration parameter::
 
     "grant_types_supported":{
       "urn:ietf:params:oauth:grant-type:token-exchange": {

--- a/src/idpyoidc/server/oauth2/token.py
+++ b/src/idpyoidc/server/oauth2/token.py
@@ -129,12 +129,15 @@ class Token(Endpoint):
         _context = self.server_get("endpoint_context")
 
         if isinstance(request, TokenExchangeRequest):
-            requested_token_type = request.get(
-                "requested_token_type",
-                self.helper["urn:ietf:params:oauth:grant-type:token-exchange"].config[
+            if "token_exchange" in _context.cdb[request["client_id"]]:
+                default_requested_token_type = _context.cdb[request["client_id"]]["token_exchange"][
                     "default_requested_token_type"
-                ],
-            )
+                ]
+            else:
+                default_requested_token_type = self.helper[
+                    "urn:ietf:params:oauth:grant-type:token-exchange"
+                ].config["default_requested_token_type"]
+            requested_token_type = request.get("requested_token_type", default_requested_token_type)
             _handler_key = TOKEN_TYPES_MAPPING[requested_token_type]
         else:
             _handler_key = "access_token"

--- a/tests/test_server_36_oauth2_token_exchange.py
+++ b/tests/test_server_36_oauth2_token_exchange.py
@@ -244,9 +244,9 @@ class TestEndpoint(object):
         Test that token exchange requests work correctly with only the required parameters
         present
         """
-        if list(token.keys())[0] == "refresh_token":
-            AUTH_REQ["scope"] = ["openid", "offline_access"]
         areq = AUTH_REQ.copy()
+        if list(token.keys())[0] == "refresh_token":
+            areq["scope"] = ["openid", "offline_access"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -288,9 +288,9 @@ class TestEndpoint(object):
         """
         Test that token exchange requests work correctly
         """
-        if list(token.keys())[0] == "refresh_token":
-            AUTH_REQ["scope"] = ["openid", "offline_access"]
         areq = AUTH_REQ.copy()
+        if list(token.keys())[0] == "refresh_token":
+            areq["scope"] = ["openid", "offline_access"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -342,6 +342,7 @@ class TestEndpoint(object):
                 "urn:ietf:params:oauth:token-type:access_token",
                 "urn:ietf:params:oauth:token-type:refresh_token",
             ],
+            "default_requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
             "policy": {
                 "": {
                     "callable": "idpyoidc.server.oauth2.token_helper.validate_token_exchange_policy",
@@ -350,9 +351,10 @@ class TestEndpoint(object):
             },
         }
 
-        if list(token.keys())[0] == "refresh_token":
-            AUTH_REQ["scope"] = ["openid", "offline_access"]
         areq = AUTH_REQ.copy()
+        if list(token.keys())[0] == "refresh_token":
+            areq["scope"] = ["openid", "offline_access"]
+        
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -509,8 +511,8 @@ class TestEndpoint(object):
         """
         Test that requesting a refresh token with audience fails.
         """
-        AUTH_REQ["scope"] = ["openid", "offline_access"]
         areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -579,8 +581,8 @@ class TestEndpoint(object):
         """
         Test whether exchanging a refresh token to another refresh token works.
         """
-        AUTH_REQ["scope"] = ["openid", "offline_access"]
         areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -615,8 +617,8 @@ class TestEndpoint(object):
         ],
     )
     def test_exchange_access_token_to_refresh_token(self, scopes):
-        AUTH_REQ["scope"] = scopes
         areq = AUTH_REQ.copy()
+        areq["scope"] = scopes
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)


### PR DESCRIPTION
- Add `_validate_configuration` that validates the token exchange configuration
- Check that `default_requested_token_type` exists in `requested_token_types_supported`
- Remove optional `subject_token_types_supported` from default Token Exchange configuration
- Fix Token Exchange tests