### PR TITLE
Fix parsing of Basic HTTP Authentication Scheme on the OP side

### DIFF
--- a/src/idpyoidc/server/client_authn.py
+++ b/src/idpyoidc/server/client_authn.py
@@ -104,11 +104,11 @@ def basic_authn(authorization_token: str):
     _tok = as_bytes(authorization_token[6:])
     # Will raise ValueError type exception if not base64 encoded
     _tok = base64.b64decode(_tok)
-    part = [unquote_plus(p) for p in as_unicode(_tok).split(":")]
-    if len(part) == 2:
-        return dict(zip(["id", "secret"], part))
-    else:
+    part = as_unicode(_tok).split(":", 1)
+    if len(part) != 2:
         raise ValueError("Illegal token")
+
+    return dict(zip(["id", "secret"], part))
 
 
 class NoneAuthn(ClientAuthnMethod):

--- a/tests/test_server_17_client_authn.py
+++ b/tests/test_server_17_client_authn.py
@@ -459,11 +459,6 @@ def test_basic_auth_wrong_label():
 
 
 def test_basic_auth_wrong_token():
-    _token = "{}:{}:foo".format(client_id, client_secret)
-    token = as_unicode(base64.b64encode(as_bytes(_token)))
-    with pytest.raises(ValueError):
-        basic_authn("Basic {}".format(token))
-
     _token = "{}:{}".format(client_id, client_secret)
     with pytest.raises(ValueError):
         basic_authn("Basic {}".format(_token))

--- a/tests/test_server_20d_client_authn.py
+++ b/tests/test_server_20d_client_authn.py
@@ -413,11 +413,6 @@ def test_basic_auth_wrong_label():
 
 
 def test_basic_auth_wrong_token():
-    _token = "{}:{}:foo".format(client_id, client_secret)
-    token = as_unicode(base64.b64encode(as_bytes(_token)))
-    with pytest.raises(ValueError):
-        basic_authn("Basic {}".format(token))
-
     _token = "{}:{}".format(client_id, client_secret)
     with pytest.raises(ValueError):
         basic_authn("Basic {}".format(_token))


### PR DESCRIPTION
- URL-encoding and decoding is not part of the Basic HTTP Authentication Scheme.
- The user-id is not allowed to contain colons (`:`).
- The password is allowed to contain colons (`:`).

Quoting https://www.rfc-editor.org/rfc/rfc7617.html
>   To receive authorization, the client
>   [...]
>   2.  constructs the user-pass by concatenating the user-id, a single
>       colon (":") character, and the password,
>   [...]
>
>   Furthermore, a user-id containing a colon character is invalid, as
>   the first colon in a user-pass string separates user-id and password
>   from one another; text after the first colon is part of the password.
>   User-ids containing colons cannot be encoded in user-pass strings.

