### PR TITLE
Fix test

### DIFF
--- a/tests/test_tandem_10_token_exchange.py
+++ b/tests/test_tandem_10_token_exchange.py
@@ -363,6 +363,7 @@ class TestEndpoint(object):
                 "urn:ietf:params:oauth:token-type:access_token",
                 "urn:ietf:params:oauth:token-type:refresh_token",
             ],
+            "default_requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
             "policy": {
                 "": {
                     "callable":


### PR DESCRIPTION
Add missing `default_requested_token_type` to `test_token_exchange_per_client` test of `test_tandem_10_token_exchange.py`