### PR TITLE
Default request arguments should be part of the service specific configuration

### DIFF
--- a/src/idpyoidc/client/entity.py
+++ b/src/idpyoidc/client/entity.py
@@ -126,7 +126,7 @@ class Entity(object):
         jwks_uri = jwks_uri or self.get_metadata_value("jwks_uri")
         set_jwks_uri_or_jwks(self, self._service_context, config, jwks_uri, _kj)
 
-        # Deal with backward compatible
+        # Deal with backward compatibility
         self.backward_compatibility(config)
 
         self.construct_uris(self._service_context.issuer,
@@ -350,6 +350,11 @@ class Entity(object):
             if key not in ["port", "domain", "httpc_params", "metadata", "client_preferences",
                            "usage", "services", "add_ons"]:
                 self.extra[key] = val
+
+        auth_request_args = config.conf.get("request_args", {})
+        if auth_request_args:
+            authz_serv = self.get_service('authorization')
+            authz_serv.default_request_args.update(auth_request_args)
 
     def config_args(self):
         res = {}

--- a/src/idpyoidc/client/oidc/authorization.py
+++ b/src/idpyoidc/client/oidc/authorization.py
@@ -32,7 +32,7 @@ class Authorization(authorization.Authorization):
 
     def __init__(self, client_get, conf=None):
         authorization.Authorization.__init__(self, client_get, conf=conf)
-        self.default_request_args = {"scope": ["openid"]}
+        self.default_request_args.update({"scope": ["openid"]})
         self.pre_construct = [
             self.set_state,
             pre_construct_pick_redirect_uri,

--- a/src/idpyoidc/client/service.py
+++ b/src/idpyoidc/client/service.py
@@ -113,6 +113,11 @@ class Service(ImpExp):
                     elif def_val is not None:
                         self.usage[param] = def_val
 
+            _default_request_args = conf.get("request_args", {})
+            if _default_request_args:
+                self.default_request_args = _default_request_args
+                del conf["request_args"]
+
         else:
             self.conf = {}
 
@@ -163,6 +168,10 @@ class Service(ImpExp):
                             val = md.get(prop)
             if val:
                 ar_args[prop] = val
+
+        for key, val in self.default_request_args.items():
+            if key not in ar_args:
+                ar_args[key] = val
 
         return ar_args
 


### PR DESCRIPTION
We had request_args as a base parameter in the client configuration and then implicit being the default request arguments to the authorization request.

Moving request_args to be part of the service configuration makes it explicit where it belongs and it also allows us to have default request args for other services.