### PR TITLE
Fix bug related to the control of claims in tokens

### DIFF
--- a/src/idpyoidc/server/session/claims.py
+++ b/src/idpyoidc/server/session/claims.py
@@ -68,11 +68,11 @@ class ClaimsInterface:
         _context = self.server_get("endpoint_context")
         add_claims_by_scope = _context.cdb[client_id].get("add_claims", {}).get("by_scope", {})
         if add_claims_by_scope:
-            _claims_by_scope = add_claims_by_scope.get(claims_release_point, False)
-            if not _claims_by_scope and secondary_identifier:
+            _claims_by_scope = add_claims_by_scope.get(claims_release_point)
+            if _claims_by_scope is None and secondary_identifier:
                 _claims_by_scope = add_claims_by_scope.get(secondary_identifier, False)
 
-            if not _claims_by_scope:
+            if _claims_by_scope is None:
                 _claims_by_scope = module.kwargs.get("add_claims_by_scope", {})
         else:
             _claims_by_scope = module.kwargs.get("add_claims_by_scope", {})


### PR DESCRIPTION
`False` is a valid value for `_claims_by_scope`, so setting this in the client's metadata will make the execution flow drop to the endpoint's global configuration .  

Ιn practice, in `_claims_by_scope = module.kwargs.get("add_claims_by_scope", {})` it's not able to differentiate whether it was set to `False` or if it was not by