### PR TITLE
Make token.JWTToken use RFC9068 as model for payload.

### DIFF
--- a/src/idpyoidc/message/oauth2/__init__.py
+++ b/src/idpyoidc/message/oauth2/__init__.py
@@ -404,6 +404,25 @@ class SecurityEventToken(Message):
         "toe": SINGLE_OPTIONAL_INT,
     }
 
+class JWTAccessToken(Message):
+    c_param = {
+        "iss": SINGLE_REQUIRED_STRING,
+        "exp": SINGLE_REQUIRED_INT,
+        "aud": REQUIRED_LIST_OF_STRINGS,
+        "sub": SINGLE_REQUIRED_STRING,
+        "client_id": SINGLE_REQUIRED_STRING,
+        "iat": SINGLE_REQUIRED_INT,
+        "jti": SINGLE_REQUIRED_STRING,
+        "auth_time": SINGLE_OPTIONAL_INT,
+        "acr": SINGLE_OPTIONAL_STRING,
+        "amr": OPTIONAL_LIST_OF_STRINGS,
+        'scope': OPTIONAL_LIST_OF_SP_SEP_STRINGS,
+        'groups': OPTIONAL_LIST_OF_STRINGS,
+        'roles': OPTIONAL_LIST_OF_STRINGS,
+        'entitlements': OPTIONAL_LIST_OF_STRINGS
+    }
+
+
 
 def factory(msgtype, **kwargs):
     """

--- a/src/idpyoidc/server/token/jwt_token.py
+++ b/src/idpyoidc/server/token/jwt_token.py
@@ -12,6 +12,8 @@ from . import Token
 from . import is_expired
 from .exception import UnknownToken
 from .exception import WrongTokenClass
+from ...message import Message
+from ...message.oauth2 import JWTAccessToken
 
 
 class JWTToken(Token):
@@ -81,6 +83,10 @@ class JWTToken(Token):
             lifetime=lifetime,
             sign_alg=self.alg,
         )
+        if isinstance(payload, Message): # don't mess with it.
+            pass
+        else:
+            payload = JWTAccessToken(**payload).to_dict()
 
         return signer.pack(payload)
 

--- a/src/idpyoidc/server/token/jwt_token.py
+++ b/src/idpyoidc/server/token/jwt_token.py
@@ -1,33 +1,36 @@
 from typing import Callable
 from typing import Optional
+from typing import Union
 
 from cryptojwt import JWT
 from cryptojwt.jws.exception import JWSException
+from cryptojwt.utils import importer
 
-from idpyoidc.encrypter import init_encrypter
 from idpyoidc.server.exception import ToOld
-
-from ..constant import DEFAULT_TOKEN_LIFETIME
-from . import Token
 from . import is_expired
+from . import Token
 from .exception import UnknownToken
 from .exception import WrongTokenClass
+from ..constant import DEFAULT_TOKEN_LIFETIME
 from ...message import Message
 from ...message.oauth2 import JWTAccessToken
 
 
 class JWTToken(Token):
+
     def __init__(
-        self,
-        token_class,
-        # keyjar: KeyJar = None,
-        issuer: str = None,
-        aud: Optional[list] = None,
-        alg: str = "ES256",
-        lifetime: int = DEFAULT_TOKEN_LIFETIME,
-        server_get: Callable = None,
-        token_type: str = "Bearer",
-        **kwargs
+            self,
+            token_class,
+            # keyjar: KeyJar = None,
+            issuer: str = None,
+            aud: Optional[list] = None,
+            alg: str = "ES256",
+            lifetime: int = DEFAULT_TOKEN_LIFETIME,
+            server_get: Callable = None,
+            token_type: str = "Bearer",
+            profile: Optional[Union[Message, str]] = JWTAccessToken,
+            with_jti: Optional[bool] = False,
+            **kwargs
     ):
         Token.__init__(self, token_class, **kwargs)
         self.token_type = token_type
@@ -42,17 +45,27 @@ class JWTToken(Token):
 
         self.def_aud = aud or []
         self.alg = alg
+        if isinstance(profile, str):
+            self.profile = importer(profile)
+        else:
+            self.profile = profile
+        self.with_jti = with_jti
+
+        if self.with_jti is False and profile == JWTAccessToken:
+            self.with_jti = True
 
     def load_custom_claims(self, payload: dict = None):
         # inherit me and do your things here
         return payload
 
     def __call__(
-        self,
-        session_id: Optional[str] = "",
-        token_class: Optional[str] = "",
-        usage_rules: Optional[dict] = None,
-        **payload
+            self,
+            session_id: Optional[str] = "",
+            token_class: Optional[str] = "",
+            usage_rules: Optional[dict] = None,
+            profile: Optional[Message] = None,
+            with_jti: Optional[bool] = None,
+            **payload
     ) -> str:
         """
         Return a token.
@@ -83,10 +96,18 @@ class JWTToken(Token):
             lifetime=lifetime,
             sign_alg=self.alg,
         )
-        if isinstance(payload, Message): # don't mess with it.
+        if isinstance(payload, Message):  # don't mess with it.
             pass
         else:
-            payload = JWTAccessToken(**payload).to_dict()
+            if profile:
+                payload = profile(**payload).to_dict()
+            elif self.profile:
+                payload = self.profile(**payload).to_dict()
+
+        if with_jti:
+            signer.with_jti = True
+        elif with_jti is None:
+            signer.with_jti = self.with_jti
 
         return signer.pack(payload)
 

--- a/tests/test_server_20e_jwt_token.py
+++ b/tests/test_server_20e_jwt_token.py
@@ -517,7 +517,7 @@ class TestEndpointWebID(object):
             grant,
             session_id,
             code,
-            scope=["openid"],
+            scope=["openid", 'foobar'],
             aud=["https://audience.example.com"],
         )
 
@@ -527,7 +527,7 @@ class TestEndpointWebID(object):
         assert _info["token_class"] == "access_token"
         # assert _info["eduperson_scoped_affiliation"] == ["staff@example.org"]
         assert set(_info["aud"]) == {"https://audience.example.com"}
-        assert _info["scope"] == ["openid"]
+        assert _info["scope"] == "openid foobar"
 
     def test_mint_with_extra(self):
         _auth_req = AuthorizationRequest(


### PR DESCRIPTION
The class JWTToken was just assuming the payload to be a dict not following any specific format.
Changed the class to use RFC9068 as model for the payload.