### PR TITLE
fix: default extended configuration, removed warning

### DIFF
--- a/src/idpyoidc/server/configure.py
+++ b/src/idpyoidc/server/configure.py
@@ -461,7 +461,7 @@ DEFAULT_EXTENDED_CONF = {
     },
     "httpc_params": {"verify": False, "timeout": 4},
     "issuer": "https://{domain}:{port}",
-    "keys": {
+    "key_conf": {
         "private_path": "private/jwks.json",
         "key_defs": [
             {"type": "RSA", "use": ["sig"]},

--- a/src/idpyoidc/server/session/manager.py
+++ b/src/idpyoidc/server/session/manager.py
@@ -495,6 +495,7 @@ class SessionManager(GrantManager):
             authorization_request: Optional[bool] = False,
             handler_key: Optional[str] = "",
     ) -> dict:
+        
         if handler_key:
             _token_info = self.token_handler.handler[handler_key].info(token_value)
         else:


### PR DESCRIPTION
Ths PR removes the WARNING below, caused by a missing update of the extended general configuration in the code.

````
WARNING  idpyoidc.server.configure:configure.py:205 key_conf does not seems to be a valid configuration parameter
````