### PR TITLE
Properly handle expired tokens on introspection endpoint

### DIFF
--- a/src/idpyoidc/server/oauth2/introspection.py
+++ b/src/idpyoidc/server/oauth2/introspection.py
@@ -6,6 +6,7 @@ from idpyoidc.message import oauth2
 from idpyoidc.server.endpoint import Endpoint
 from idpyoidc.server.token.exception import UnknownToken
 from idpyoidc.server.token.exception import WrongTokenClass
+from idpyoidc.server.exception import ToOld
 
 LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class Introspection(Endpoint):
             _session_info = _context.session_manager.get_session_info_by_token(
                 request_token, grant=True
             )
-        except (UnknownToken, WrongTokenClass):
+        except (UnknownToken, WrongTokenClass, ToOld):
             return {"response_args": _resp}
 
         grant = _session_info["grant"]

--- a/tests/test_server_31_oauth2_introspection.py
+++ b/tests/test_server_31_oauth2_introspection.py
@@ -457,9 +457,14 @@ class TestEndpoint:
         _resp = self.introspection_endpoint.process_request(_req)
         assert _resp["response_args"]["active"] is False
 
-    def test_expired_access_token(self):
+    def test_expired_access_token(self, monkeypatch):
         access_token = self._get_access_token(AUTH_REQ)
-        access_token.expires_at = utc_time_sans_frac() - 1000
+        lifetime = self.session_manager.token_handler.handler["access_token"].lifetime
+
+        def mock():
+            return utc_time_sans_frac() + lifetime + 1
+
+        monkeypatch.setattr("idpyoidc.server.token.utc_time_sans_frac", mock)
 
         _context = self.introspection_endpoint.server_get("endpoint_context")
 


### PR DESCRIPTION
    This change is important to properly mark token with `active: false` on the introspection endpoint, when the token has expired.

_Originally posted by @c00kiemon5ter in https://github.com/IdentityPython/idpy-oidc/pull/39#discussion_r1080618611_
            