### PR TITLE
Enforce aud restrictions

### DIFF
--- a/src/idpyoidc/server/oauth2/introspection.py
+++ b/src/idpyoidc/server/oauth2/introspection.py
@@ -110,6 +110,13 @@ class Introspection(Endpoint):
         grant = _session_info["grant"]
         _token = grant.get_token(request_token)
 
+        aud = _token.resources
+        if not aud:
+            aud = grant.resources
+        
+        if request["client_id"] not in aud:
+            return {"response_args": _resp}
+
         _info = self._introspect(_token, _session_info["client_id"], _session_info["grant"])
         if _info is None:
             return {"response_args": _resp}

--- a/tests/test_server_31_oauth2_introspection.py
+++ b/tests/test_server_31_oauth2_introspection.py
@@ -494,6 +494,23 @@ class TestEndpoint:
         _resp = self.introspection_endpoint.process_request(_req)
         assert _resp["response_args"]["active"] is False
 
+    def test_wrong_aud(self):
+        auth_req = AUTH_REQ.copy()
+        auth_req["client_id"] = "client_2"
+        access_token = self._get_access_token(auth_req)
+
+        _context = self.introspection_endpoint.server_get("endpoint_context")
+
+        _req = self.introspection_endpoint.parse_request(
+            {
+                "token": access_token.value,
+                "client_id": "client_1",
+                "client_secret": _context.cdb["client_1"]["client_secret"],
+            }
+        )
+        _resp = self.introspection_endpoint.process_request(_req)
+        assert _resp["response_args"]["active"] is False
+
     def test_introspect_id_token(self):
         session_id = self._create_session(AUTH_REQ)
         grant = self.token_endpoint.server_get("endpoint_context").authz(session_id, AUTH_REQ)


### PR DESCRIPTION
The following behavior was identified and resolved:

- Generate an access-token with Client-A. The token has aud: `[client-a]`
- Introspect the access-token with Client-B.
- Response is `active: true`, plus information about the token.

The expectation was to get `active: false` because the token was not intended to be used by Client-B.

With these changes the introspection endpoint will
- check the audience before returning a reply
- will return `active: false` if the token is sent by a client that is not within the audience of the token