### PR TITLE
Fix refresh grant on access token helper after fedservice

### DIFF
--- a/src/idpyoidc/server/oidc/token_helper/access_token.py
+++ b/src/idpyoidc/server/oidc/token_helper/access_token.py
@@ -119,7 +119,6 @@ class AccessTokenHelper(TokenEndpointHelper):
         if (
                 issue_refresh
                 and "refresh_token" in _supports_minting
-                and "refresh_token" in grant_types_supported
         ):
             try:
                 refresh_token = self._mint_token(

--- a/tests/test_server_31_oauth2_introspection.py
+++ b/tests/test_server_31_oauth2_introspection.py
@@ -498,8 +498,7 @@ class TestEndpoint:
         auth_req = AUTH_REQ.copy()
         auth_req["client_id"] = "client_2"
         access_token = self._get_access_token(auth_req)
-
-        _context = self.introspection_endpoint.server_get("endpoint_context")
+        _context = self.introspection_endpoint.upstream_get("endpoint_context")
 
         _req = self.introspection_endpoint.parse_request(
             {


### PR DESCRIPTION
This change was initially introduced in #48 and was reverted in fedservice