### PR TITLE
Unbind authentication event lifetime from userinfo response

### DIFF
--- a/src/idpyoidc/server/oidc/userinfo.py
+++ b/src/idpyoidc/server/oidc/userinfo.py
@@ -133,44 +133,22 @@ class UserInfo(Endpoint):
         if token.is_active() is False:
             return self.error_cls(error="invalid_token", error_description="Invalid Token")
 
-        allowed = True
-        _auth_event = _grant.authentication_event
-        # if the authentication is still active or offline_access is granted.
-        if not _auth_event["valid_until"] >= utc_time_sans_frac():
-            logger.debug(
-                "authentication not valid: {} > {}".format(
-                    datetime.fromtimestamp(_auth_event["valid_until"]),
-                    datetime.fromtimestamp(utc_time_sans_frac()),
-                )
-            )
-            allowed = False
+        _cntxt = self.upstream_get("context")
+        _claims_restriction = _cntxt.claims_interface.get_claims(
+            _session_info["branch_id"], scopes=token.scope, claims_release_point="userinfo"
+        )
+        info = _cntxt.claims_interface.get_user_claims(
+            _session_info["user_id"], claims_restriction=_claims_restriction
+        )
+        info["sub"] = _grant.sub
+        if _grant.add_acr_value("userinfo"):
+            info["acr"] = _grant.authentication_event["authn_info"]
 
-            # This has to be made more fine grained.
-            # if "offline_access" in session["authn_req"]["scope"]:
-            #     pass
+        if "userinfo" in _cntxt.cdb[request["client_id"]]:
+            self.config["policy"] = _cntxt.cdb[request["client_id"]]["userinfo"]["policy"]
 
-        if allowed:
-            _cntxt = self.upstream_get("context")
-            _claims_restriction = _cntxt.claims_interface.get_claims(
-                _session_info["branch_id"], scopes=token.scope, claims_release_point="userinfo"
-            )
-            info = _cntxt.claims_interface.get_user_claims(
-                _session_info["user_id"], claims_restriction=_claims_restriction
-            )
-            info["sub"] = _grant.sub
-            if _grant.add_acr_value("userinfo"):
-                info["acr"] = _grant.authentication_event["authn_info"]
-
-            if "userinfo" in _cntxt.cdb[request["client_id"]]:
-                self.config["policy"] = _cntxt.cdb[request["client_id"]]["userinfo"]["policy"]
-
-            if "policy" in self.config:
-                info = self._enforce_policy(request, info, token, self.config)
-        else:
-            info = {
-                "error": "invalid_request",
-                "error_description": "Access not granted",
-            }
+        if "policy" in self.config:
+            info = self._enforce_policy(request, info, token, self.config)
 
         return {"response_args": info, "client_id": _session_info["client_id"]}
 

--- a/tests/test_server_26_oidc_userinfo_endpoint.py
+++ b/tests/test_server_26_oidc_userinfo_endpoint.py
@@ -310,24 +310,6 @@ class TestEndpoint(object):
         args = self.endpoint.process_request(_req, http_info=http_info)
         assert args
 
-    def test_process_request_not_allowed(self):
-        session_id = self._create_session(AUTH_REQ)
-        grant = self.session_manager[session_id]
-        code = self._mint_code(grant, session_id)
-        access_token = self._mint_token("access_token", grant, session_id, code)
-
-        # 2 things can make the request invalid.
-        # 1) The token is not valid anymore or 2) The event is not valid.
-        _event = grant.authentication_event
-        _event["authn_time"] -= 9000
-        _event["valid_until"] -= 9000
-
-        http_info = {"headers": {"authorization": "Bearer {}".format(access_token.value)}}
-        _req = self.endpoint.parse_request({}, http_info=http_info)
-
-        args = self.endpoint.process_request(_req, http_info=http_info)
-        assert set(args["response_args"].keys()) == {"error", "error_description"}
-
     def test_do_response(self):
         session_id = self._create_session(AUTH_REQ)
         grant = self.session_manager[session_id]


### PR DESCRIPTION
This MR unbinds the authentication event lifetime validation from the userinfo response.
The userinfo endpoint should only consider the provided token, that must fulfill the following criteria:

- the token is an access-token
- the access-token is valid (not expired or revoked)
- the access-token includes the openid scope