### PR TITLE
Fix RP-Initiated Logout in example.

### DIFF
--- a/src/idpyoidc/server/client_authn.py
+++ b/src/idpyoidc/server/client_authn.py
@@ -123,7 +123,7 @@ class NoneAuthn(ClientAuthnMethod):
         endpoint=None,  # Optional[Endpoint]
         **kwargs,
     ):
-        return {"client_id": request.get("client_id")}
+        return {"client_id": request.get("client_id"), "token": authorization_token}
 
 
 class PublicAuthn(ClientAuthnMethod):


### PR DESCRIPTION
Try to fix https://github.com/IdentityPython/idpy-oidc/issues/67#issuecomment-1686132208

`NoneAuthn. _verify` needs to return a `"token"` in `auth_info` to pass `Session.parse_request`