### PR TITLE
Optional resource attribute enforcement

### DIFF
--- a/src/idpyoidc/server/oauth2/authorization.py
+++ b/src/idpyoidc/server/oauth2/authorization.py
@@ -339,6 +339,11 @@ def validate_resource_indicators_policy(request, context, **kwargs):
     request["scope"] = scopes
     return request
 
+def optional_validate_resource_indicators_policy(request, context, **kwargs):
+    if "resource" not in request:
+        return request
+
+    return validate_resource_indicators_policy(request, context, **kwargs)
 
 class Authorization(Endpoint):
     request_cls = oauth2.AuthorizationRequest

--- a/src/idpyoidc/server/oauth2/authorization.py
+++ b/src/idpyoidc/server/oauth2/authorization.py
@@ -292,10 +292,7 @@ def check_unknown_scopes_policy(request_info, client_id, context):
 
 def validate_resource_indicators_policy(request, context, **kwargs):
     if "resource" not in request:
-        return oauth2.AuthorizationErrorResponse(
-            error="invalid_target",
-            error_description="Missing resource parameter",
-        )
+        return request
 
     resource_servers_per_client = kwargs["resource_servers_per_client"]
     client_id = request["client_id"]
@@ -339,11 +336,6 @@ def validate_resource_indicators_policy(request, context, **kwargs):
     request["scope"] = scopes
     return request
 
-def optional_validate_resource_indicators_policy(request, context, **kwargs):
-    if "resource" not in request:
-        return request
-
-    return validate_resource_indicators_policy(request, context, **kwargs)
 
 class Authorization(Endpoint):
     request_cls = oauth2.AuthorizationRequest

--- a/tests/test_server_24_oauth2_resource_indicators.py
+++ b/tests/test_server_24_oauth2_resource_indicators.py
@@ -522,8 +522,11 @@ class TestEndpoint(object):
         )
 
         msg = self.endpoint._post_parse_request(request, "client_1", endpoint_context)
-        assert "error" in msg
-        assert msg["error_description"] == "Missing resource parameter"
+
+        assert "error" not in msg
+        assert isinstance(msg, AuthorizationRequest)
+        for key, _ in request.items():
+            assert msg[key] == request[key]
 
     def test_authorization_code_req_no_resource_indicators_disabled(
         self, create_endpoint_ri_disabled


### PR DESCRIPTION
Fixes #81

Provides a wrapper method that does not return an error when the validate resource attribute policy is set but the attribute is not provided in the client's request.