### PR TITLE
Redirect URI comparison for native OAuth clients (RFC 8252)

### DIFF
--- a/private/xmetadata/oidc.py
+++ b/private/xmetadata/oidc.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from idpyoidc import metadata
 from idpyoidc.client import metadata as client_metadata
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.message.oidc import RegistrationResponse
 
@@ -64,7 +65,7 @@ class Metadata(client_metadata.Metadata):
 
     _supports = {
         "acr_values_supported": None,
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "callback_uris": None,
         # "client_authn_methods": get_client_authn_methods,
         "client_id": None,

--- a/src/idpyoidc/client/claims/oidc.py
+++ b/src/idpyoidc/client/claims/oidc.py
@@ -5,6 +5,7 @@ from typing import Optional
 from idpyoidc import metadata
 from idpyoidc.client import claims as client_claims
 from idpyoidc.client.claims.transform import create_registration_request
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.message.oidc import RegistrationResponse
 
@@ -63,7 +64,7 @@ class Claims(client_claims.Claims):
 
     _supports = {
         "acr_values_supported": None,
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "callback_uris": None,
         # "client_authn_methods": get_client_authn_methods,
         "client_id": None,

--- a/src/idpyoidc/client/defaults.py
+++ b/src/idpyoidc/client/defaults.py
@@ -1,6 +1,8 @@
 import hashlib
 import string
 
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
+
 SUCCESSFUL = [200, 201, 202, 203, 204, 205, 206]
 
 SERVICE_NAME = "OIC"
@@ -27,7 +29,7 @@ DEFAULT_OAUTH2_SERVICES = {
 }
 
 DEFAULT_CLIENT_PREFERENCES = {
-    "application_type": "web",
+    "application_type": APPLICATION_TYPE_WEB,
     "response_types": [
         "code",
         "id_token",

--- a/src/idpyoidc/message/oidc/__init__.py
+++ b/src/idpyoidc/message/oidc/__init__.py
@@ -47,6 +47,9 @@ logger = logging.getLogger(__name__)
 
 NONCE_STORAGE_TIME = 4 * 3600
 
+APPLICATION_TYPE_NATIVE = "native"
+APPLICATION_TYPE_WEB = "web"
+
 
 class AtHashError(VerificationError):
     pass
@@ -638,9 +641,9 @@ class RegistrationRequest(Message):
         # "organization_name": SINGLE_OPTIONAL_STRING,
         "response_modes": OPTIONAL_LIST_OF_STRINGS,
     }
-    c_default = {"application_type": "web", "response_types": ["code"]}
+    c_default = {"application_type": APPLICATION_TYPE_WEB, "response_types": ["code"]}
     c_allowed_values = {
-        "application_type": ["native", "web"],
+        "application_type": [APPLICATION_TYPE_NATIVE, APPLICATION_TYPE_WEB],
         "subject_type": ["public", "pairwise"],
     }
 

--- a/src/idpyoidc/server/exception.py
+++ b/src/idpyoidc/server/exception.py
@@ -66,7 +66,7 @@ class UnknownAssertionType(OidcEndpointError):
     pass
 
 
-class RedirectURIError(OidcEndpointError):
+class RedirectURIError(OidcEndpointError, ValueError):
     pass
 
 

--- a/src/idpyoidc/server/oidc/registration.py
+++ b/src/idpyoidc/server/oidc/registration.py
@@ -13,6 +13,8 @@ from cryptojwt.utils import as_bytes
 
 from idpyoidc.exception import MessageException
 from idpyoidc.message.oauth2 import ResponseMessage
+from idpyoidc.message.oidc import APPLICATION_TYPE_NATIVE
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import ClientRegistrationErrorResponse
 from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.message.oidc import RegistrationResponse
@@ -291,10 +293,10 @@ class Registration(Endpoint):
     @staticmethod
     def verify_redirect_uris(registration_request):
         verified_redirect_uris = []
-        client_type = registration_request.get("application_type", "web")
+        client_type = registration_request.get("application_type") or APPLICATION_TYPE_WEB
 
         must_https = False
-        if client_type == "web":
+        if client_type == APPLICATION_TYPE_WEB:
             must_https = True
             if registration_request.get("response_types") == ["code"]:
                 must_https = False
@@ -302,7 +304,7 @@ class Registration(Endpoint):
         for uri in registration_request["redirect_uris"]:
             _custom = False
             p = urlparse(uri)
-            if client_type == "native":
+            if client_type == APPLICATION_TYPE_NATIVE:
                 if p.scheme not in ["http", "https"]:  # Custom scheme
                     _custom = True
                 elif p.scheme == "http" and p.hostname in ["localhost", "127.0.0.1"]:

--- a/tests/test_06_oidc.py
+++ b/tests/test_06_oidc.py
@@ -27,6 +27,7 @@ from idpyoidc.message.oidc import JRD
 from idpyoidc.message.oidc import AccessTokenRequest
 from idpyoidc.message.oidc import AccessTokenResponse
 from idpyoidc.message.oidc import AddressClaim
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import AtHashError
 from idpyoidc.message.oidc import AuthnToken
 from idpyoidc.message.oidc import AuthorizationErrorResponse
@@ -549,7 +550,7 @@ class TestProviderConfigurationResponse(object):
 class TestRegistrationRequest(object):
     def test_deserialize(self):
         msg = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",
@@ -579,7 +580,7 @@ class TestRegistrationRequest(object):
             default_max_age=10,
             require_auth_time=True,
             default_acr="foo",
-            application_type="web",
+            application_type=APPLICATION_TYPE_WEB,
             redirect_uris=["https://example.com/authz_cb"],
         )
         assert req.verify()
@@ -587,7 +588,7 @@ class TestRegistrationRequest(object):
         js_obj = json.loads(js)
         expected_js_obj = {
             "redirect_uris": ["https://example.com/authz_cb"],
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "default_acr": "foo",
             "require_auth_time": True,
             "operation": "register",
@@ -624,7 +625,7 @@ class TestRegistrationRequest(object):
             default_max_age=10,
             require_auth_time=True,
             default_acr="foo",
-            application_type="web",
+            application_type=APPLICATION_TYPE_WEB,
             redirect_uris=["https://example.com/authz_cb"],
         )
         ser_req = req.serialize("urlencoded")
@@ -645,7 +646,7 @@ class TestRegistrationRequest(object):
             "default_max_age": 10,
             "require_auth_time": True,
             "default_acr": "foo",
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": ["https://example.com/authz_cb"],
         }
 
@@ -666,7 +667,7 @@ class TestRegistrationRequest(object):
             "default_max_age": 10,
             "require_auth_time": True,
             "default_acr": "foo",
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": ["https://example.com/authz_cb"],
         }
 
@@ -692,7 +693,7 @@ class TestRegistrationResponse(object):
             "registration_client_uri": "https://server.example.com/connect/register?client_id"
             "=s6BhdRkqt3",
             "token_endpoint_auth_method": "client_secret_basic",
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",

--- a/tests/test_08_transform.py
+++ b/tests/test_08_transform.py
@@ -7,6 +7,7 @@ from idpyoidc.client.claims.oidc import Claims as OIDC_Claims
 from idpyoidc.client.claims.transform import create_registration_request
 from idpyoidc.client.claims.transform import preferred_to_registered
 from idpyoidc.client.claims.transform import supported_to_preferred
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import ProviderConfigurationResponse
 from idpyoidc.message.oidc import RegistrationRequest
 
@@ -307,7 +308,7 @@ class TestTransform2:
 
         self.supported = supported
         preference = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",
@@ -376,7 +377,7 @@ class TestTransform2:
         assert registration_request["subject_type"] == "public"
 
         registration_response = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",

--- a/tests/test_09_work_condition.py
+++ b/tests/test_09_work_condition.py
@@ -7,6 +7,7 @@ from idpyoidc.client.claims.oidc import Claims
 from idpyoidc.client.claims.transform import create_registration_request
 from idpyoidc.client.claims.transform import preferred_to_registered
 from idpyoidc.client.claims.transform import supported_to_preferred
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 
 KEYSPEC = [
     {"type": "RSA", "use": ["sig"]},
@@ -46,7 +47,7 @@ class TestWorkEnvironment:
     def test_load_conf(self):
         # Only symmetric key
         client_conf = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",
@@ -65,7 +66,7 @@ class TestWorkEnvironment:
     def test_load_jwks(self):
         # Symmetric and asymmetric keys published as JWKS
         client_conf = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "base_url": "https://client.example.org/",
             "redirect_uris": [
                 "https://client.example.org/callback",
@@ -86,7 +87,7 @@ class TestWorkEnvironment:
     def test_load_jwks_uri1(self):
         # Symmetric and asymmetric keys published through a jwks_uri
         client_conf = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "base_url": "https://client.example.org/",
             "redirect_uris": [
                 "https://client.example.org/callback",
@@ -108,7 +109,7 @@ class TestWorkEnvironment:
     def test_load_jwks_uri2(self):
         # Symmetric and asymmetric keys published through a jwks_uri
         client_conf = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "base_url": "https://client.example.org/",
             "redirect_uris": [
                 "https://client.example.org/callback",
@@ -127,7 +128,7 @@ class TestWorkEnvironment:
 
     def test_registration_response(self):
         client_conf = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "base_url": "https://client.example.org/",
             "redirect_uris": [
                 "https://client.example.org/callback",
@@ -197,7 +198,7 @@ class TestWorkEnvironment:
         assert registration_request["subject_type"] == "public"
 
         registration_response = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",

--- a/tests/test_client_02_entity.py
+++ b/tests/test_client_02_entity.py
@@ -2,6 +2,7 @@ import pytest
 
 from idpyoidc.client.client_auth import ClientAuthnMethod
 from idpyoidc.client.entity import Entity
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 
 KEYDEFS = [
     {"type": "RSA", "key": "", "use": ["sig"]},
@@ -61,7 +62,7 @@ KEYSPEC = [
 
 def test_client_authn_default():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "keys": {"key_defs": KEYSPEC, "read_only": True},
@@ -74,7 +75,7 @@ def test_client_authn_default():
 
 def test_client_authn_by_names():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "keys": {"key_defs": KEYSPEC, "read_only": True},
@@ -99,7 +100,7 @@ class FooBar(ClientAuthnMethod):
 
 def test_client_authn_full():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "keys": {"key_defs": KEYSPEC, "read_only": True},
@@ -121,7 +122,7 @@ def test_client_authn_full():
 
 def test_service_specific():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "keys": {"key_defs": KEYSPEC, "read_only": True},
@@ -150,7 +151,7 @@ def test_service_specific():
 
 def test_service_specific2():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "keys": {"key_defs": KEYSPEC, "read_only": True},

--- a/tests/test_client_02b_entity_metadata.py
+++ b/tests/test_client_02b_entity_metadata.py
@@ -1,6 +1,7 @@
 from cryptojwt.key_jar import init_key_jar
 
 from idpyoidc.client.entity import Entity
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationRequest
 
 ISS = "http://example.org/op"
@@ -12,7 +13,7 @@ CLIENT_CONFIG = {
     "issuer": ISS,
     "application_name": "rphandler",
     "preference": {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": "support@example.com",
         "response_types_supported": ["code"],
         "request_parameter": "request_uri",

--- a/tests/test_client_14_service_context_impexp.py
+++ b/tests/test_client_14_service_context_impexp.py
@@ -7,6 +7,7 @@ from cryptojwt.key_jar import build_keyjar
 
 from idpyoidc.client.entity import Entity
 from idpyoidc.client.service_context import ServiceContext
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 
 BASE_URL = "https://example.com"
 
@@ -111,7 +112,7 @@ class TestClientInfo(object):
 
     def test_registration_userinfo_sign_enc_algs(self):
         self.service_context.claims.use = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",
@@ -130,7 +131,7 @@ class TestClientInfo(object):
 
     def test_registration_request_object_sign_enc_algs(self):
         self.service_context.claims.use = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",
@@ -152,7 +153,7 @@ class TestClientInfo(object):
 
     def test_registration_id_token_sign_enc_algs(self):
         self.service_context.claims.use = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "redirect_uris": [
                 "https://client.example.org/callback",
                 "https://client.example.org/callback2",

--- a/tests/test_client_21_oidc_service.py
+++ b/tests/test_client_21_oidc_service.py
@@ -16,6 +16,7 @@ from idpyoidc.client.oidc.registration import response_types_to_grant_types
 from idpyoidc.exception import MissingRequiredAttribute
 from idpyoidc.message.oidc import AccessTokenRequest
 from idpyoidc.message.oidc import AccessTokenResponse
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import AuthorizationRequest
 from idpyoidc.message.oidc import AuthorizationResponse
 from idpyoidc.message.oidc import IdToken
@@ -483,7 +484,7 @@ class TestProviderInfo(object):
             "redirect_uris": ["https://example.com/cli/authz_cb"],
             "issuer": self._iss,
             "application_name": "rphandler",
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "contacts": ["ops@example.org"],
             "preference": {
                 "scope": ["openid", "profile", "email", "address", "phone"],
@@ -744,7 +745,7 @@ class TestProviderInfo(object):
         del use_copy["callback_uris"]
 
         assert use_copy == {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "backchannel_logout_session_required": True,
             "backchannel_logout_uri": "https://rp.example.com/back",
             "client_id": "client_id",
@@ -831,7 +832,7 @@ class TestProviderInfo(object):
         del use_copy["callback_uris"]
 
         assert use_copy == {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "backchannel_logout_session_required": True,
             "backchannel_logout_uri": "https://rp.example.com/back",
             "client_id": "client_id",

--- a/tests/test_client_26_read_registration.py
+++ b/tests/test_client_26_read_registration.py
@@ -7,6 +7,7 @@ from cryptojwt.utils import as_bytes
 
 import requests
 from idpyoidc.client.entity import Entity
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationResponse
 
 ISS = "https://example.com"
@@ -21,7 +22,7 @@ class TestRegistrationRead(object):
             "issuer": self._iss,
             "requests_dir": "requests",
             "base_url": "https://example.com/cli/",
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "response_types_supported": ["code"],
             "contacts": ["ops@example.org"],
             "jwks_uri": "https://example.com/rp/static/jwks.json",
@@ -61,7 +62,7 @@ class TestRegistrationRead(object):
                 "registration_client_uri": "{}/registration_api?client_id=zls2qhN1jO6A".format(ISS),
                 "client_secret_expires_at": now + 3600,
                 "client_id_issued_at": now,
-                "application_type": "web",
+                "application_type": APPLICATION_TYPE_WEB,
                 "response_types": ["code"],
                 "contacts": ["ops@example.com"],
                 "redirect_uris": ["{}/authz_cb".format(RP_BASEURL)],

--- a/tests/test_client_27_conversation.py
+++ b/tests/test_client_27_conversation.py
@@ -11,6 +11,7 @@ from idpyoidc.client.entity import Entity
 from idpyoidc.client.oidc.webfinger import WebFinger
 from idpyoidc.message.oidc import JRD
 from idpyoidc.message.oidc import AccessTokenResponse
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import AuthorizationResponse
 from idpyoidc.message.oidc import Link
 from idpyoidc.message.oidc import OpenIDSchema
@@ -116,7 +117,7 @@ SERVICES = {
 
 def test_conversation():
     config = {
-        "application_type": "web",
+        "application_type": APPLICATION_TYPE_WEB,
         "contacts": ["ops@example.org"],
         "redirect_uris": [f"{RP_BASEURL}/authz_cb"],
         "response_types": ["code"],
@@ -429,7 +430,7 @@ def test_conversation():
             "registration_client_uri": f"{RP_BASEURL}/registration?client_id=zls2qhN1jO6A",
             "client_secret_expires_at": now + 3600,
             "client_id_issued_at": now,
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "response_types": ["code"],
             "contacts": ["ops@example.com"],
             "redirect_uris": [f"{RP_BASEURL}/authz_cb"],

--- a/tests/test_client_30_rp_handler_oidc.py
+++ b/tests/test_client_30_rp_handler_oidc.py
@@ -11,6 +11,7 @@ import responses
 from idpyoidc.client.entity import Entity
 from idpyoidc.client.rp_handler import RPHandler
 from idpyoidc.message.oidc import AccessTokenResponse
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import AuthorizationResponse
 from idpyoidc.message.oidc import IdToken
 from idpyoidc.message.oidc import JRD
@@ -23,7 +24,7 @@ from idpyoidc.util import rndstr
 BASE_URL = "https://example.com/rp"
 
 PREF = {
-    "application_type": "web",
+    "application_type": APPLICATION_TYPE_WEB,
     "contacts": ["ops@example.com"],
     "response_types_supported": [
         "code",
@@ -1019,7 +1020,7 @@ class TestRPHandlerWithMockOP(object):
         }
         pcr = ProviderConfigurationResponse(**resp)
         _crr = {
-            "application_type": "web",
+            "application_type": APPLICATION_TYPE_WEB,
             "response_types": ["code", "code id_token"],
             "redirect_uris": [
                 "https://example.com/rp/authz_cb"

--- a/tests/test_client_41_rp_handler_persistent.py
+++ b/tests/test_client_41_rp_handler_persistent.py
@@ -7,13 +7,14 @@ from cryptojwt.key_jar import init_key_jar
 
 from idpyoidc.client.rp_handler import RPHandler
 from idpyoidc.message.oidc import AccessTokenResponse
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import AuthorizationResponse
 from idpyoidc.message.oidc import IdToken
 
 BASE_URL = "https://example.com/rp"
 
 PREFERENCE = {
-    "application_type": "web",
+    "application_type": APPLICATION_TYPE_WEB,
     "contacts": ["ops@example.com"],
     "response_types": [
         "code",

--- a/tests/test_server_23_oidc_registration_endpoint.py
+++ b/tests/test_server_23_oidc_registration_endpoint.py
@@ -6,6 +6,8 @@ import pytest
 import responses
 from cryptojwt.key_jar import init_key_jar
 
+from idpyoidc.message.oidc import APPLICATION_TYPE_NATIVE
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.message.oidc import RegistrationResponse
 from idpyoidc.server import Server
@@ -48,7 +50,7 @@ RESPONSE_TYPES_SUPPORTED = [
 
 MSG = {
     "client_id": "client_id",
-    "application_type": "web",
+    "application_type": APPLICATION_TYPE_WEB,
     "redirect_uris": [
         "https://client.example.org/callback",
         "https://client.example.org/callback2",
@@ -269,7 +271,7 @@ class TestEndpoint(object):
     def test_register_custom_redirect_uri_native(self):
         _msg = MSG.copy()
         _msg["redirect_uris"] = ["custom://cb.example.com"]
-        _msg["application_type"] = "native"
+        _msg["application_type"] = APPLICATION_TYPE_NATIVE
         _req = self.endpoint.parse_request(RegistrationRequest(**_msg).to_json())
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -287,7 +289,7 @@ class TestEndpoint(object):
 
         _msg = MSG.copy()
         _msg["redirect_uris"] = ["custom://cb.example.com"]
-        _msg["application_type"] = "native"
+        _msg["application_type"] = APPLICATION_TYPE_NATIVE
         _msg["sector_identifier_uri"] = _url
 
         _req = self.endpoint.parse_request(RegistrationRequest(**_msg).to_json())

--- a/tests/test_server_32_oidc_read_registration.py
+++ b/tests/test_server_32_oidc_read_registration.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from idpyoidc.message.oidc import APPLICATION_TYPE_WEB
 from idpyoidc.message.oidc import RegistrationRequest
 from idpyoidc.server import Server
 from idpyoidc.server.configure import OPConfiguration
@@ -51,7 +52,7 @@ CAPABILITIES = {
 
 msg = {
     "client_id": "client_1",
-    "application_type": "web",
+    "application_type": APPLICATION_TYPE_WEB,
     "redirect_uris": [
         "https://client.example.org/callback",
         "https://client.example.org/callback2",


### PR DESCRIPTION
Native Applications have to use ephemeral ports in the redirect_uri. This is something that is already addressed by the RFCs:

[Draft-ietf-oauth-security-topics-27](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-countermeasures): This document therefore advises simplifying the required logic and configuration by using exact redirect URI matching ... The only exception is native apps using a localhost URI: In this case, the authorization server MUST allow variable port numbers as described in [RFC8252], Section 7.3.
 
[RFC 8252: OAuth 2.0 for Native Apps (rfc-editor.org)](https://www.rfc-editor.org/rfc/rfc8252.html#page-9): Native apps that are able to open a port on the loopback network interface without needing special permissions (typically, those on desktop operating systems) can use the loopback interface to receive the OAuth redirect. Loopback redirect URIs use the "http" scheme and are constructed with the loopback IP literal and whatever port the client is listening on. That is, "http://127.0.0.1:{port}/{path}" for IPv4, and "http://[::1]:{port}/{path}" for IPv6.