### PR TITLE
Update OIDC id_token_signing_alg_values_supported for wider algo support

### DIFF
--- a/src/idpyoidc/message/oidc/__init__.py
+++ b/src/idpyoidc/message/oidc/__init__.py
@@ -942,8 +942,14 @@ class ProviderConfigurationResponse(ResponseMessage):
                 "token_endpoint_auth_signing_alg_values_supported"
             )
 
-        if "RS256" not in self["id_token_signing_alg_values_supported"]:
-            raise ValueError("RS256 missing from id_token_signing_alg_values_supported")
+        # Check that any alg that is not "none" is supported.
+        # While OpenID Connect Core 1.0 says RS256 MUST be supported,
+        # reality has moved on and more modern alg values may be required.
+        if not any(i.lower() != "none" for i in self["id_token_signing_alg_values_supported"]):
+            raise ValueError(
+                "Secure signing algorithm (for example RS256 or ES256) missing from id_token_signing_alg_values_supported: %s"
+                % self["id_token_signing_alg_values_supported"]
+            )
 
         if not parts.query and not parts.fragment:
             pass

--- a/tests/test_06_oidc.py
+++ b/tests/test_06_oidc.py
@@ -470,6 +470,7 @@ class TestProviderConfigurationResponse(object):
         [
             "issuer",
             "authorization_endpoint",
+            "token_endpoint",
             "jwks_uri",
             "response_types_supported",
             "subject_types_supported",
@@ -480,6 +481,7 @@ class TestProviderConfigurationResponse(object):
         provider_config = {
             "issuer": "https://server.example.com",
             "authorization_endpoint": "https://server.example.com/connect/authorize",
+            "token_endpoint": "https://server.example.com/connect/token",
             "jwks_uri": "https://server.example.com/jwks.json",
             "response_types_supported": ["code", "code id_token", "id_token", "token id_token"],
             "subject_types_supported": ["public", "pairwise"],
@@ -520,19 +522,20 @@ class TestProviderConfigurationResponse(object):
         provider_config = {
             "issuer": "https://server.example.com",
             "authorization_endpoint": "https://server.example.com/connect/authorize",
+            "token_endpoint": "https://server.example.com/connect/token",
             "jwks_uri": "https://server.example.com/jwks.json",
             "response_types_supported": ["code", "code id_token", "id_token", "token id_token"],
             "subject_types_supported": ["public", "pairwise"],
             "id_token_signing_alg_values_supported": ["none", "ES256", "HS256"],
         }
 
-        with pytest.raises(MissingRequiredAttribute):
-            ProviderConfigurationResponse(**provider_config).verify()
+        assert ProviderConfigurationResponse(**provider_config).verify()
 
     def test_required_parameters_only_none_signing_alg(self):
         provider_config = {
             "issuer": "https://server.example.com",
             "authorization_endpoint": "https://server.example.com/connect/authorize",
+            "token_endpoint": "https://server.example.com/connect/token",
             "jwks_uri": "https://server.example.com/jwks.json",
             "response_types_supported": ["code", "code id_token", "id_token", "token id_token"],
             "subject_types_supported": ["public", "pairwise"],

--- a/tests/test_06_oidc.py
+++ b/tests/test_06_oidc.py
@@ -516,6 +516,32 @@ class TestProviderConfigurationResponse(object):
         with pytest.raises(MissingRequiredAttribute):
             ProviderConfigurationResponse(**provider_config).verify()
 
+    def test_required_parameters_without_rs256(self):
+        provider_config = {
+            "issuer": "https://server.example.com",
+            "authorization_endpoint": "https://server.example.com/connect/authorize",
+            "jwks_uri": "https://server.example.com/jwks.json",
+            "response_types_supported": ["code", "code id_token", "id_token", "token id_token"],
+            "subject_types_supported": ["public", "pairwise"],
+            "id_token_signing_alg_values_supported": ["none", "ES256", "HS256"],
+        }
+
+        with pytest.raises(MissingRequiredAttribute):
+            ProviderConfigurationResponse(**provider_config).verify()
+
+    def test_required_parameters_only_none_signing_alg(self):
+        provider_config = {
+            "issuer": "https://server.example.com",
+            "authorization_endpoint": "https://server.example.com/connect/authorize",
+            "jwks_uri": "https://server.example.com/jwks.json",
+            "response_types_supported": ["code", "code id_token", "id_token", "token id_token"],
+            "subject_types_supported": ["public", "pairwise"],
+            "id_token_signing_alg_values_supported": ["none"],
+        }
+
+        with pytest.raises(ValueError):
+            ProviderConfigurationResponse(**provider_config).verify()
+
 
 class TestRegistrationRequest(object):
     def test_deserialize(self):


### PR DESCRIPTION
Previously the message verification required RS256 with no other checks
on algo. While technically RS256 MUST be supported, some implementations
have abandoned it's use as insecure and instead require for example
ES256 as a minimum baseline. Fixes #110

This change slightly relaxes the check in a future compatible way while
still making sure an actual alg is specified instead of `none`.


Logic test, `True` triggers validation failure.
```python
>>> bad = ["none"]
>>> good = ["ES256"]
>>> dodgy = ["none", "RS256"]
>>> empty = []
>>> not any(i.lower() != "none" for i in empty)
True
>>> not any(i.lower() != "none" for i in bad)
True
>>> not any(i.lower() != "none" for i in dodgy)
False
>>> not any(i.lower() != "none" for i in good)
False
```
