### PR TITLE
chore: gitignore more test artefacts to avoid accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,14 @@ coverage.xml
 *.cover
 .hypothesis/
 
+# Test artefacts
+static/
+requests/
+request123456.jwt
+private/cookie_jwks.json
+private/jwks.json
+private/token_jwks.json
+
 # Translations
 *.mo
 *.pot

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+read_only


### PR DESCRIPTION
This does not ignore all signatures that may change as part of running
tests as I wasn't sure if it's intentional that they're stored in the
first place.
