### PR TITLE
Fix Per-Client Lifetime for id_token

### DIFF
--- a/src/idpyoidc/server/token/id_token.py
+++ b/src/idpyoidc/server/token/id_token.py
@@ -299,7 +299,10 @@ class IDToken(Token):
         else:
             xargs = {}
 
-        lifetime = self.lifetime
+        if usage_rules and "expires_in" in usage_rules:
+            lifetime = usage_rules.get("expires_in")
+        else:
+            lifetime = self.lifetime
 
         id_token = self.sign_encrypt(
             session_id,

--- a/tests/test_server_08_id_token.py
+++ b/tests/test_server_08_id_token.py
@@ -294,7 +294,6 @@ class TestEndpoint(object):
             "email_verified",
             "jti",
             "scope",
-            "client_id",
             "iss",
             "sid",
         }        


### PR DESCRIPTION
This PR addresses an issue where the id_token lifetime was not properly handled on a per-client basis.  