### PR TITLE
make RP aware of running behind ssl terminating front end proxy

### DIFF
--- a/example/flask_rp/wsgi.py
+++ b/example/flask_rp/wsgi.py
@@ -8,6 +8,8 @@ from idpyoidc.client.configure import RPHConfiguration
 from idpyoidc.configure import create_from_config_file
 from idpyoidc.ssl_context import create_context
 
+from werkzeug.middleware.proxy_fix import ProxyFix
+
 try:
     from . import application
 except ImportError:
@@ -25,6 +27,10 @@ if __name__ == "__main__":
                                       filename=conf)
 
     app = application.oidc_provider_init_app(_config.rp, name, template_folder=template_dir)
+    
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1, x_prefix=1)
+
+    
     _web_conf = _config.web_conf
     context = create_context(dir_path, _web_conf)
 


### PR DESCRIPTION
The exisiting Flask RP example application was not recoginizing X-Forwarded-* headers properly. For example if you run the example application behind a Treafik Proxy which is terminating TLS, the flask-rp application publishing http:// urls when registering itself at the Flaks-OP Provider instance.
This PR make use of the ProxyFix method to make the flask application acknownledge the forwarded headers properly.
Refer: https://werkzeug.palletsprojects.com/en/stable/middleware/proxy_fix/